### PR TITLE
fix return index is int bug

### DIFF
--- a/torch_pruning/prune/strategy.py
+++ b/torch_pruning/prune/strategy.py
@@ -30,7 +30,7 @@ class LNStrategy(BaseStrategy):
         l1_norm = torch.norm( weights.view(n, -1), p=self.p, dim=1 )
         n_to_prune = int(amount*n)
         threshold = torch.kthvalue(l1_norm, k=n_to_prune).values 
-        indices = torch.nonzero(l1_norm <= threshold).squeeze().tolist()
+        indices = torch.nonzero(l1_norm <= threshold).view(-1).tolist()
         return indices
 
 class L1Strategy(LNStrategy):


### PR DESCRIPTION
when runing ```torch.nonzero(l1_norm <= threshold)```, if only one value in ```l1_norm```  meet the conditions, ```.squeeze().tolist()``` will return a int number. 

Modify to ```.view(-1).tolist()``` will fix this problem.