### PR TITLE
fix n_to_prune zero bug

### DIFF
--- a/torch_pruning/prune/strategy.py
+++ b/torch_pruning/prune/strategy.py
@@ -29,6 +29,8 @@ class LNStrategy(BaseStrategy):
         n = len(weights)
         l1_norm = torch.norm( weights.view(n, -1), p=self.p, dim=1 )
         n_to_prune = int(amount*n)
+        if n_to_prune == 0:
+            return []
         threshold = torch.kthvalue(l1_norm, k=n_to_prune).values 
         indices = torch.nonzero(l1_norm <= threshold).squeeze().tolist()
         return indices


### PR DESCRIPTION
if ```n_to_prune``` is 0, ``` torch.kthvalue``` will get error RuntimeError: selected index k out of range