### PR TITLE
bugfix: remove call to method of NoneType

### DIFF
--- a/torch_pruning/dependency.py
+++ b/torch_pruning/dependency.py
@@ -453,7 +453,8 @@ class DependencyGraph(object):
     
     def _obtain_forward_graph(self, model, example_inputs, output_transform, pruning_dim):
         #module_to_node = { m: Node( m ) for m in model.modules() if isinstance( m, self.PRUNABLE_MODULES ) }
-        model.eval().cpu()
+        model.eval()
+        model.cpu()
         # Get grad_fn from prunable modules
         grad_fn_to_module = {}
 


### PR DESCRIPTION
In some versions of torch, `model.cpu()` and `model.eval()` return None, and the code fails at the fixed line.