### PR TITLE
fix bug:inversed_idx do not match the origin index

### DIFF
--- a/torch_pruning/pruner/importance.py
+++ b/torch_pruning/pruner/importance.py
@@ -73,13 +73,11 @@ class MagnitudeImportance(Importance):
         self.bias = bias
 
     def _lamp(self, imp): # Layer-adaptive Sparsity for the Magnitude-based Pruning
-        argsort_idx = torch.argsort(imp, dim=0, descending=True).tolist()
-        sorted_imp = imp[argsort_idx]
+        argsort_idx = torch.argsort(imp, dim=0, descending=True)
+        sorted_imp = imp[argsort_idx.tolist()]
         cumsum_imp = torch.cumsum(sorted_imp, dim=0)
         sorted_imp = sorted_imp / cumsum_imp
-        inversed_idx = torch.arange(len(sorted_imp))[
-            argsort_idx
-        ].tolist()  # [0, 1, 2, 3, ..., ]
+        inversed_idx = torch.argsort(argsort_idx).tolist()  # [0, 1, 2, 3, ..., ]
         return sorted_imp[inversed_idx]
     
     def _normalize(self, group_importance, normalizer):


### PR DESCRIPTION
```python
import torch
def _lamp(imp): # Layer-adaptive Sparsity for the Magnitude-based Pruning
    argsort_idx = torch.argsort(imp, dim=0, descending=True)
    sorted_imp = imp[argsort_idx.tolist()]
   
    inversed_idx1 = torch.argsort(argsort_idx).tolist()
    inversed_idx2 = torch.arange(len(sorted_imp))[
        argsort_idx
    ].tolist()  # [0, 1, 2, 3, ..., ]
    return sorted_imp[inversed_idx1],sorted_imp[inversed_idx2]

a=torch.tensor([3,1,2,4,5])
out1,out2 = _lamp(a)
print(a)
print(out1)
print(out2)

#-------out
#tensor([3, 1, 2, 4, 5])
#tensor([3, 1, 2, 4, 5])
#tensor([1, 2, 5, 3, 4])
```
Obviously, the index `inversed_idx2 ` cannot restore `sorted_imp` to `imp`,
` inversed_idx = torch.arange(len(sorted_imp))[argsort_idx]` is equivalent to `inversed_idx=argsort_idx`