### PR TITLE
fix error: unwrapped parameter not in the forward_fn

### DIFF
--- a/torch_pruning/dependency.py
+++ b/torch_pruning/dependency.py
@@ -847,7 +847,8 @@ class DependencyGraph(object):
 
         
         for (param, dim) in self.unwrapped_parameters:
-            module2node[param].pruning_dim = dim
+            if param in module2node:
+                module2node[param].pruning_dim = dim
         return module2node
 
     def update_index_mapping(self):


### PR DESCRIPTION
KeyError  of dict occurs while a unwrapped parameter is not in the forward_fn, which would cause the prune process blocking. Therefore, we need to check whether the parameter has been registered as a node.