### PR TITLE
Fix split pruning for multiple iterative_steps

### DIFF
--- a/tests/test_concat_split.py
+++ b/tests/test_concat_split.py
@@ -51,7 +51,7 @@ def test_pruner():
         if isinstance(m, torch.nn.Linear) and m.out_features == 1000:
             ignored_layers.append(m)
 
-    iterative_steps = 1
+    iterative_steps = 2
     pruner = tp.pruner.MagnitudePruner(
         model,
         example_inputs,

--- a/tests/test_non_feature_dim_cat.py
+++ b/tests/test_non_feature_dim_cat.py
@@ -49,7 +49,7 @@ def test_pruner():
         if isinstance(m, torch.nn.Linear) and m.out_features == 1000:
             ignored_layers.append(m)
 
-    iterative_steps = 1
+    iterative_steps = 2
     pruner = tp.pruner.MagnitudePruner(
         model,
         example_inputs,

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -53,7 +53,7 @@ def test_pruner():
         if isinstance(m, torch.nn.Linear) and m.out_features == 1000:
             ignored_layers.append(m)
 
-    iterative_steps = 1
+    iterative_steps = 2
     pruner = tp.pruner.MagnitudePruner(
         model,
         example_inputs,

--- a/torch_pruning/ops.py
+++ b/torch_pruning/ops.py
@@ -135,7 +135,7 @@ class SplitPruner(DummyPruner):
         offsets = [0]
         for i in range(len(new_split_sizes)):
             offsets.append(offsets[i] + new_split_sizes[i])
-        self.offsets = offsets
+        layer.offsets = offsets
 
     prune_in_channels = prune_out_channels
         


### PR DESCRIPTION
The SplitPruner updates self.offsets instead of layer.offsets causing index errors when using iterative_steps > 1

Reproducible by setting iterative_steps=2 in the test_concat_split.py and test_split.py tests