### PR TITLE
Feature: Improve Iterative Pruning: Verify Pruning Status Before Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ if isinstance(imp, tp.importance.GroupTaylorImportance):
     loss = model(example_inputs).sum() # A dummy loss, please replace this line with your loss function and data!
     loss.backward() # before pruner.step()
 
-pruner.step()
-macs, nparams = tp.utils.count_ops_and_params(model, example_inputs)
-# finetune the pruned model here
-# finetune(model)
-# ...
+if pruner.step():
+    macs, nparams = tp.utils.count_ops_and_params(model, example_inputs)
+    # finetune the pruned model here
+    # finetune(model)
+    # ...
 ```
 #### Global Pruning
 

--- a/torch_pruning/pruner/algorithms/metapruner.py
+++ b/torch_pruning/pruner/algorithms/metapruner.py
@@ -227,10 +227,15 @@ class MetaPruner:
         if interactive: # yield groups for interactive pruning
             return pruning_method() 
         else:
+            pruned = False
             for group in pruning_method():
                 group.prune()
+                pruned = True
                 # print("gg")
             # exit(0)
+            return pruned
+            
+
 
     def manual_prune(self, layer, pruning_fn, pruning_ratios_or_idxs):
         if isinstance(pruning_ratios_or_idxs, float):


### PR DESCRIPTION
Hello, I've noticed that during iterative pruning, the model might not necessarily undergo pruning after each step (pruning generator does not return anything - is empty). Since the iterative pruning process involves a cycle of pruning and training, it would be beneficial to verify whether the model has been pruned after each step, rather than proceeding directly to training.

Here's a scenario where this improvement could be useful: currently, after calling the `step()` function of the pruning algorithm, we proceed to training the model without confirming if pruning has actually occurred. This can lead to unnecessary training cycles on an unpruned model.

To address this, we can modify the `step()` method within the MetaPruner class. By introducing a return value to indicate whether pruning has taken place, we can optimize the training process. Below is a simple suggested implementation:

```python
def step(self, interactive=False) -> typing.Union[typing.Generator, None]:
    self.current_step += 1
    pruning_method = self.prune_global if self.global_pruning else self.prune_local

    if interactive: 
        return pruning_method() # yield groups for interactive pruning
    else:
        pruned = False
        for group in pruning_method():
            group.prune()
            pruned = True
        return pruned
```

With this enhancement, before initiating training, we can easily check if pruning has occurred after calling `step()`. This allows us to seamlessly continue our iterative loop without unnecessary training cycles on an unpruned model.