### PR TITLE
fixed potentially buggy typo

### DIFF
--- a/torch_pruning/pruner/algorithms/group_norm_pruner.py
+++ b/torch_pruning/pruner/algorithms/group_norm_pruner.py
@@ -121,7 +121,7 @@ class GroupNormPruner(MetaPruner):
         self._groups = list(self.DG.get_all_groups(root_module_types=self.root_module_types, ignored_layers=self.ignored_layers))
         self.cnt = 0
 
-    def update_regularizor(self):
+    def update_regularizer(self):
         self._groups = list(self.DG.get_all_groups(root_module_types=self.root_module_types, ignored_layers=self.ignored_layers))
 
     @torch.no_grad()

--- a/torch_pruning/pruner/algorithms/growing_reg_pruner.py
+++ b/torch_pruning/pruner/algorithms/growing_reg_pruner.py
@@ -134,7 +134,7 @@ class GrowingRegPruner(MetaPruner):
             reg = reg + self.delta_reg * standarized_imp.to(reg.device)
             self.group_reg[group] = reg
 
-    def update_regularizor(self):
+    def update_regularizer(self):
         # Update the group list after pruning
         self._groups = list(self.DG.get_all_groups(root_module_types=self.root_module_types, ignored_layers=self.ignored_layers))
         group_reg = {}


### PR DESCRIPTION
the name of the function "update_regularizer" was different from that of the base MetaPruner class, so it wasn't properly overwritten. Also, in the benchmark example "reproduce/main.py" such function is never called, even though in README.md it's indicated that to apply sparse training, it should be called at the beginning of each epoch. Is this a mistake in the code? Or is it really not necessary to make such function call?