### PR TITLE
[fix] Clarify variable naming in linear_scheduler function, add typing

### DIFF
--- a/torch_pruning/pruner/algorithms/scheduler.py
+++ b/torch_pruning/pruner/algorithms/scheduler.py
@@ -1,3 +1,5 @@
+from typing import List
 
-def linear_scheduler(pruning_ratio_dict, steps):
-    return [((i) / float(steps)) * pruning_ratio_dict for i in range(steps+1)]
+
+def linear_scheduler(pruning_ratio: float, steps: int) -> List[float]:
+    return [((i) / float(steps)) * pruning_ratio for i in range(steps + 1)]


### PR DESCRIPTION
**Subject**: Clarify variable naming in linear_scheduler function

**Description**:
Thank you for the work on the code!

While adding my own custom schedulers compatible with Torch-Pruning, I noticed an issue with the existing linear_scheduler function:

```python
def linear_scheduler(pruning_ratio_dict, steps):
    return [((i) / float(steps)) * pruning_ratio_dict for i in range(steps+1)]
```
The variable name pruning_ratio_dict suggests it holds a dictionary, but later in the code, a float value is passed. This caused some confusion for me during implementation. To clarify, I have:
- Renamed pruning_ratio_dict to pruning_ratio to reflect its actual use as a float.
- Added type annotations to improve code clarity.

Here’s the updated function:

```python
from typing import List

def linear_scheduler(pruning_ratio: float, steps: int) -> List[float]:
    return [(i / float(steps)) * pruning_ratio for i in range(steps + 1)]
```

I think this change improves readability and eliminates the confusion caused by the original variable name.