### PR TITLE
BatchnormPruner: Skip running mean/var when tracking_running_stats=False

### DIFF
--- a/torch_pruning/pruner/function.py
+++ b/torch_pruning/pruner/function.py
@@ -204,8 +204,9 @@ class BatchnormPruner(BasePruningFunc):
         keep_idxs = list(set(range(layer.num_features)) - set(idxs))
         keep_idxs.sort()
         layer.num_features = layer.num_features-len(idxs)
-        layer.running_mean = layer.running_mean.data[keep_idxs]
-        layer.running_var = layer.running_var.data[keep_idxs]
+        if layer.track_running_stats:
+            layer.running_mean = layer.running_mean.data[keep_idxs]
+            layer.running_var = layer.running_var.data[keep_idxs]
 
         if layer.affine:
             layer.weight = self._prune_parameter_and_grad(layer.weight, keep_idxs, 0)


### PR DESCRIPTION
 When tracking_running_stats is set to false, a batchnorm layer doesn't have running_mean/running_var in weights, thus error occurred:
  File "/usr/local/lib/python3.10/dist-packages/torch_pruning-1.5.1-py3.10.egg/torch_pruning/pruner/function.py", line 207, in prune_out_channels
    AttributeError: 'NoneType' object has no attribute 'data'

 * Ref: https://github.com/pytorch/pytorch/blob/b16ae97ad03a6f376988e505fa23734523d0b4c5/torch/nn/modules/batchnorm.py#L61