### PR TITLE
Add dependency type in `details()`

### DIFF
--- a/torch_pruning/dependency.py
+++ b/torch_pruning/dependency.py
@@ -267,10 +267,15 @@ class Group(object):
         fmt += " " * 10 + "Pruning Group"
         fmt += "\n" + "-" * 32 + "\n"
         for i, (dep, idxs) in enumerate(self._group):
-            if i==0: 
-                fmt += "[{}] {}, idxs ({}) ={}  (Pruning Root)\n".format(i, dep, len(idxs), idxs)
+            # Determine dependency type
+            dep_type = "Intra" if dep.source.module == dep.target.module else "Inter"
+
+            if i==0:
+                fmt += "[{}] {}, idxs ({}) ={}  (Pruning Root) | {}\n".format(
+                    i, dep, len(idxs), idxs, dep_type)
             else:
-                fmt += "[{}] {}, idxs ({}) ={} \n".format(i, dep, len(idxs), idxs)
+                fmt += "[{}] {}, idxs ({}) ={} | {}\n".format(
+                    i, dep, len(idxs), idxs, dep_type)
         fmt += "-" * 32 + "\n"
         return fmt
 


### PR DESCRIPTION
- Close : #482 

This update shows the type of dependency (intra/internal) for better understanding of DepGraph.

Although intra/internal dependency-building logics are separated, there were no log messages showing if the dependency is intra or internal.

For better understanding, this update adds the type of dependency.

For example:
```
# Old
> group.details()
--------------------------------
          Pruning Group
--------------------------------
[0] Conv4 → Conv4, idxs (2) =[0, 1]
[1] Conv4 → BN5, idxs (2) =[0, 1]
[2] BN5 → BN5, idxs (2) =[0, 1]
[3] BN5 → ReLU6, idxs (2) =[0, 1]
[4] ReLU6 → ReLU6, idxs (2) =[0, 1]
[5] ReLU6 → Add7, idxs (2) =[0, 1]
```

```
# New
> group.details()
--------------------------------
          Pruning Group
--------------------------------
[0] Conv4 → Conv4, idxs (2) =[0, 1]
[1] Conv4 → BN5, idxs (2) =[0, 1]    | Inter
[2] BN5 → BN5, idxs (2) =[0, 1]      | Intra
[3] BN5 → ReLU6, idxs (2) =[0, 1]    | Inter
[4] ReLU6 → ReLU6, idxs (2) =[0, 1]  | Intra
[5] ReLU6 → Add7, idxs (2) =[0, 1]   | Inter
```