### PR TITLE
Update Sparse Training Params in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ for epoch in range(epochs):
         out = model(data)
         loss = F.cross_entropy(out, target)
         loss.backward() # after loss.backward()
-        pruner.regularize(model) # <== for sparse training
+        pruner.regularize(model, loss) # <== for sparse training
         optimizer.step() # before optimizer.step()
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -225,7 +225,7 @@ for epoch in range(epochs):
         out = model(data)
         loss = F.cross_entropy(out, target)
         loss.backward() # after loss.backward()
-        pruner.regularize(model) # <== for sparse training
+        pruner.regularize(model, loss) # <== for sparse training
         optimizer.step() # before optimizer.step()
 ```
 


### PR DESCRIPTION
When deploying sparse training, I found that `pruner.regularize()` requires two parameters, `model` and `loss`, so I modified the example in README.